### PR TITLE
tests solution

### DIFF
--- a/src/validateRegisterForm.test.js
+++ b/src/validateRegisterForm.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 'use strict';
 
 describe(`Function 'validateRegisterForm':`, () => {
@@ -8,8 +9,7 @@ describe(`Function 'validateRegisterForm':`, () => {
   });
 
   it(`should return object`, () => {
-    expect(typeof validateRegisterForm('test@mail.com', 'P@ssword1!'))
-      .toBe('object');
+    expect(typeof validateRegisterForm('test@gmail.com', 'P@ssword1!')).toBe('object');
   });
 
   it(`should return success message for the valid input`, () => {
@@ -19,12 +19,88 @@ describe(`Function 'validateRegisterForm':`, () => {
     expect(isValid.message).toBe('Email and password are valid.');
   });
 
-  it(`should return error for valid email and password without number`, () => {
+  it(`should return error for valid email and password that is too short`, () => {
+    const invalidPassword = validateRegisterForm('test@mail.com', 'P1!');
+
+    expect(invalidPassword.code).toBe(422);
+    expect(invalidPassword.message).toBe('Password is invalid.');
+  });
+
+  it(`should return error for valid email and password that is too long`, () => {
+    const invalidPassword = validateRegisterForm('test@mail.com', 'Password123456789!');
+
+    expect(invalidPassword.code).toBe(422);
+    expect(invalidPassword.message).toBe('Password is invalid.');
+  });
+
+  it(`should return error for valid email and password without digit`, () => {
     const invalidPassword = validateRegisterForm('test@mail.com', 'P@ssword');
 
     expect(invalidPassword.code).toBe(422);
     expect(invalidPassword.message).toBe('Password is invalid.');
   });
 
-  // write more tests here
+  it(`should return error for valid email and password without special character`, () => {
+    const invalidPassword = validateRegisterForm('test@mail.com', 'Password1');
+
+    expect(invalidPassword.code).toBe(422);
+    expect(invalidPassword.message).toBe('Password is invalid.');
+  });
+
+  it(`should return error for valid email and password without uppercase letter`, () => {
+    const invalidPassword = validateRegisterForm('test@mail.com', 'password1!');
+
+    expect(invalidPassword.code).toBe(422);
+    expect(invalidPassword.message).toBe('Password is invalid.');
+  });
+
+  it(`should return error for invalid email and valid password`, () => {
+    const invalidEmail = validateRegisterForm('invalid-email', 'P@ssword1!');
+
+    expect(invalidEmail.code).toBe(422);
+    expect(invalidEmail.message).toBe('Email is invalid.');
+  });
+
+  it(`should return error for email with invalid domain and valid password with digit`, () => {
+    const invalidEmail = validateRegisterForm('test@com', 'P@ssword1!');
+
+    expect(invalidEmail.code).toBe(422);
+    expect(invalidEmail.message).toBe('Email is invalid.');
+  });
+
+  it(`should return error for password containing any specified special characters`, () => {
+    const specialChars = "!#$%&'*+-/=?^_`{|}~";
+    const isValid = validateRegisterForm(`te${specialChars}st@mail.com`, `P@ssword1!`);
+
+    expect(isValid.code).toBe(422);
+    expect(isValid.message).toBe('Email is invalid.');
+  });
+
+  it(`should return error for email starting with a dot and valid password`, () => {
+    const invalidEmail = validateRegisterForm('.test@mail.com', 'P@ssword1!');
+
+    expect(invalidEmail.code).toBe(422);
+    expect(invalidEmail.message).toBe('Email is invalid.');
+  });
+
+  it(`should return error for email with double dots and valid password`, () => {
+    const invalidEmail = validateRegisterForm('test..email@mail.com', 'P@ssword1!');
+
+    expect(invalidEmail.code).toBe(422);
+    expect(invalidEmail.message).toBe('Email is invalid.');
+  });
+
+  // it(`should return error for email with top-level domain starting with dot and valid password`, () => {
+  //   const invalidEmail = validateRegisterForm('test@mail..com', 'P@ssword1!');
+
+  //   expect(invalidEmail.code).toBe(422);
+  //   expect(invalidEmail.message).toBe('Email is invalid.');
+  // });
+
+  it(`should return error for email ending with dot and valid password`, () => {
+    const invalidEmail = validateRegisterForm('test@.mail.com.', 'P@ssword1!');
+
+    expect(invalidEmail.code).toBe(422);
+    expect(invalidEmail.message).toBe('Email is invalid.');
+  });
 });


### PR DESCRIPTION
As far as I can see, there is a condition that _the top level domain cannot start with a dot_ , i.e. the following email: test@gmail..com is not valid, if you leave it in front of 'com' with another dot, however the regex `validEmailMask` does not match this, so I left it commented out before the last test, or I misunderstood something)